### PR TITLE
chore(*): dont enable module stability in case of xcframework

### DIFF
--- a/lib/cocoapods-binary-cache/pod-rome/xcodebuild_command.rb
+++ b/lib/cocoapods-binary-cache/pod-rome/xcodebuild_command.rb
@@ -62,7 +62,6 @@ module PodPrebuild
       args_[:device] ||= []
       args_[:default].prepend("BITCODE_GENERATION_MODE=bitcode") if bitcode_enabled?
       args_[:default].prepend("DEBUG_INFORMATION_FORMAT=dwarf") if disable_dsym?
-      args_[:default].prepend("BUILD_LIBRARY_FOR_DISTRIBUTION=YES") if PodPrebuild.config.xcframework?
       args_[:simulator].prepend("ARCHS=x86_64", "ONLY_ACTIVE_ARCH=NO") if simulator == "iphonesimulator"
       args_[:simulator] += args_[:default]
       args_[:device].prepend("ONLY_ACTIVE_ARCH=NO")
@@ -89,7 +88,7 @@ module PodPrebuild
       output = "#{output_path(target)}/#{target.product_module_name}.xcframework"
       FileUtils.rm_rf(output)
 
-      cmd = ["xcodebuild", " -create-xcframework"]
+      cmd = ["xcodebuild", " -create-xcframework", "-allow-internal-distribution"]
       cmd += sdks.map { |sdk| "-framework #{framework_path_of(target, sdk)}" }
       cmd << "-output" << output
       `#{cmd.join(" ")}`


### PR DESCRIPTION
<!--
  Thanks for contributing to our project.
  To make the issue more descriptive and easier to categorize, please prefix the issue title with `feature request:`.
  Following are some good examples:
    - `feature request: allow running code generation before prebuilding`
    - `feature request: allow customization for fetcher/pusher`
-->

### Checklist
<!-- Kindly check the following items by replacing `[ ]` with `[x]` -->
- [ ] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [ ] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [ ] I've run `bundle exec rubocop` to check code style

### Description
<!-- Describe your changes here -->
<details><pre>[Details go here]</pre></details>
