### PR TITLE
fix #56: skip integrating targets for prebuild installer

### DIFF
--- a/lib/cocoapods-binary-cache/pod-binary/prebuild.rb
+++ b/lib/cocoapods-binary-cache/pod-binary/prebuild.rb
@@ -14,6 +14,13 @@ module Pod
       @lockfile_wrapper = lockfile && PodPrebuild::Lockfile.new(lockfile)
     end
 
+    def installation_options
+      # Skip integrating user targets for prebuild Pods project.
+      @installation_options ||= Pod::Installer::InstallationOptions.new(
+        super.to_h.merge(:integrate_targets => false)
+      )
+    end
+
     def run_code_gen!(targets)
       return if PodPrebuild.config.prebuild_code_gen.nil?
 


### PR DESCRIPTION
<!--
  Thanks for contributing to our project.
  To make the issue more descriptive and easier to categorize, please prefix the issue title with `feature request:`.
  Following are some good examples:
    - `feature request: allow running code generation before prebuilding`
    - `feature request: allow customization for fetcher/pusher`
-->

### Checklist
<!-- Kindly check the following items by replacing `[ ]` with `[x]` -->
- [ ] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [ ] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [ ] I've run `bundle exec rubocop` to check code style

### Description
<!-- Describe your changes here -->
<details><pre>[Details go here]</pre></details>
